### PR TITLE
Fix initial step to use config.json located in the installed folder

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -134,7 +134,7 @@ commander.parse(process.argv);
 
 if ( ! process.argv.slice(2).length ) {
 
-    if ( fs.existsSync(JSON.parse(fs.readFileSync("config.json")).location ) ) {
+    if ( fs.existsSync(JSON.parse(fs.readFileSync(__dirname + "/config.json")).location ) ) {
 	commander.outputHelp();
 	process.exit(0);
     }


### PR DESCRIPTION
When installing globally I was getting an error:
`Error: ENOENT: no such file or directory, open 'config.json'`
This happens because the code was trying to load `config.json` from the current working directory, and not from the `__dirname` path, which is where the file actually is when the package is installed by npm.
